### PR TITLE
Slightly more cross platform static preferred linking that still allo…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,14 @@ set(CMAKE_TOOLCHAIN_FILE "")
 set(USE_ABSEIL OFF) # Default USE_ABSEIL explicitly turned OFF
 
 if(WIN32) # Windows static extension is .lib
-    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
     if(MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2")
     else(MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O3")
     endif(MSVC)
 else(WIN32)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES .a .so)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -O3")
 endif(WIN32)
 


### PR DESCRIPTION
what @kpu suggested. I'm in favor of keeping static linking since most of marian/bergamot translator does this anyways.