### PR TITLE
Prefer non-debug PCRE2 for windows vcpkg installation

### DIFF
--- a/cmake/FindPCRE2.cmake
+++ b/cmake/FindPCRE2.cmake
@@ -63,7 +63,7 @@ if(SSPLIT_USE_INTERNAL_PCRE2)
 
 else(SSPLIT_USE_INTERNAL_PCRE2)
   
-  find_library(PCRE2_LIBRARIES NAMES pcre2 pcre2-8 pcre2-8-staticd pcre2-posix-staticd)
+  find_library(PCRE2_LIBRARIES NAMES pcre2 pcre2-8 pcre2-8-static pcre2-posix-static pcre2-8-staticd pcre2-posix-staticd)
   find_path(PCRE2_INCLUDE_DIRS pcre2.h)
 
 endif(SSPLIT_USE_INTERNAL_PCRE2)


### PR DESCRIPTION
When compiling on windows with vcpkg installed pcre2, we want to prefer the non-debug version. VCPKG by default produces debug and non debug binaries, but through some clever configuration settings you can make it just produce the non-debug version. That however makes it impossible to find pcre2 by cmake and breaks the windows build.  I hope this would fix the issue.